### PR TITLE
Support homebrew gcc-5

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 ### Changed
 - when installing into an Anaconda distribution, drop -march=native compiler flag
   due to assembler issues.
+- when installing on OSX, search macports and homebrew install location for gcc
+  version 5.x
 
 ## [1.5][2015-09-24]
 ### Changed

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,9 @@ def set_gcc():
 
     # For macports and homebrew
     patterns = ['/opt/local/bin/gcc-mp-[0-9].[0-9]',
-                '/usr/local/bin/gcc-[0-9].[0-9]']
+                '/opt/local/bin/gcc-mp-[0-9]',
+                '/usr/local/bin/gcc-[0-9].[0-9]',
+                '/usr/local/bin/gcc-[0-9]']
 
     if 'darwin' in platform.platform().lower():
 


### PR DESCRIPTION
when homebrew installed gcc it created these links:

```
$ ls -alh /usr/local/bin/gcc*
lrwxr-xr-x  1 jongwook  admin    29B Sep 15 00:55 /usr/local/bin/gcc-5 -> ../Cellar/gcc/5.2.0/bin/gcc-5
lrwxr-xr-x  1 jongwook  admin    32B Sep 15 00:55 /usr/local/bin/gcc-ar-5 -> ../Cellar/gcc/5.2.0/bin/gcc-ar-5
lrwxr-xr-x  1 jongwook  admin    32B Sep 15 00:55 /usr/local/bin/gcc-nm-5 -> ../Cellar/gcc/5.2.0/bin/gcc-nm-5
lrwxr-xr-x  1 jongwook  admin    36B Sep 15 00:55 /usr/local/bin/gcc-ranlib-5 -> ../Cellar/gcc/5.2.0/bin/gcc-ranlib-5
```

which setup.py didn't pick up. 

this commit is on top of your pull request #26 and should be merged after.