### PR TITLE
fix numpy VisibleDeprecationWarning

### DIFF
--- a/lightfm/datasets/stackexchange.py
+++ b/lightfm/datasets/stackexchange.py
@@ -97,8 +97,8 @@ def fetch_stackexchange(dataset, test_set_fraction=0.2,
                                      shape=data['features_shape'].flatten())
     tag_labels = data['labels']
 
-    test_cutoff_timestamp = np.sort(interactions.data)[len(interactions.data) *
-                                                       (1.0 - test_set_fraction)]
+    test_cutoff_index = int(len(interactions.data) * (1.0 - test_set_fraction))
+    test_cutoff_timestamp = np.sort(interactions.data)[test_cutoff_index]
     in_train = interactions.data < test_cutoff_timestamp
     in_test = np.logical_not(in_train)
 


### PR DESCRIPTION
fix the warning:
```sh
lightfm/datasets/stackexchange.py:101: VisibleDeprecationWarning: using a non-integer number instead of an integer will result in an error in the future
  * (1.0 - test_set_fraction)]
```