### PR TITLE
Update evaluation.py - include case where k = 1

### DIFF
--- a/lightfm/evaluation.py
+++ b/lightfm/evaluation.py
@@ -62,8 +62,11 @@ def precision_at_k(model, test_interactions, train_interactions=None,
                                item_features=item_features,
                                num_threads=num_threads)
 
-    ranks.data[ranks.data < k] = 1.0
-    ranks.data[ranks.data >= k] = 0.0
+    k_inds = ranks.data < k
+    other_inds = ranks.data >= k
+
+    ranks.data[k_inds] = 1.0
+    ranks.data[other_inds] = 0.0
 
     precision = np.squeeze(np.array(ranks.sum(axis=1))) / k
 


### PR DESCRIPTION
For the case where k = 1, setting all the rank=0 values to '1' is immediately overwritten. By saving-off the indices first, the ranks data is updated without this issue.