### PR TITLE
Reformat where it's sensible (PEP8), Add coding=utf-8 comments

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -3,3 +3,4 @@ Jong Wook Kim
 Maciej Kula
 Paolo Rais
 Kent Shikama
+Mice Pápai

--- a/lightfm/evaluation.py
+++ b/lightfm/evaluation.py
@@ -1,13 +1,13 @@
+# coding=utf-8
 """
-Module containing evaluation functions suitable for judging the performance of a fitted
-LightFM model.
+Module containing evaluation functions suitable for judging the performance of 
+a fitted LightFM model.
 """
 
 import numpy as np
 
 from ._lightfm_fast import (CSRMatrix,
                             calculate_auc_from_rank)
-
 
 __all__ = ['precision_at_k',
            'recall_at_k',
@@ -19,8 +19,8 @@ def precision_at_k(model, test_interactions, train_interactions=None,
                    k=10, user_features=None, item_features=None,
                    preserve_rows=False, num_threads=1):
     """
-    Measure the precision at k metric for a model: the fraction of known positives in the first k
-    positions of the ranked list of results.
+    Measure the precision at k metric for a model: the fraction of known 
+    positives in the first k positions of the ranked list of results.
     A perfect score is 1.0.
 
     Parameters
@@ -32,7 +32,7 @@ def precision_at_k(model, test_interactions, train_interactions=None,
          Non-zero entries representing known positives in the evaluation set.
     train_interactions: np.float32 csr_matrix of shape [n_users, n_items], optional
          Non-zero entries representing known positives in the train set. These
-         will be omitted from the score calulations to avoid re-recommending
+         will be omitted from the score calculations to avoid re-recommending
          known positives.
     k: integer, optional
          The k parameter.
@@ -41,9 +41,10 @@ def precision_at_k(model, test_interactions, train_interactions=None,
     item_features: np.float32 csr_matrix of shape [n_items, n_item_features], optional
          Each row contains that item's weights over features.
     preserve_rows: boolean, optional
-         When False (default), the number of rows in the output will be equal to
-         the number of users with interactions in the evaluation set. When True,
-         the number of rows in the output will be equal to the number of users.
+         When False (default), the number of rows in the output will be equal
+         to the number of users with interactions in the evaluation set.
+         When True, the number of rows in the output will be equal to the
+         number of users.
     num_threads: int, optional
          Number of parallel computation threads to use. Should
          not be higher than the number of physical cores.
@@ -52,8 +53,8 @@ def precision_at_k(model, test_interactions, train_interactions=None,
     -------
 
     np.array of shape [n_users with interactions or n_users,]
-         Numpy array containing precision@k scores for each user. If there are no interactions
-         for a given user the returned precision will be 0.
+         Numpy array containing precision@k scores for each user. If there are 
+         no interactions for a given user the returned precision will be 0.
     """
 
     ranks = model.predict_rank(test_interactions,
@@ -76,9 +77,9 @@ def recall_at_k(model, test_interactions, train_interactions=None,
                 k=10, user_features=None, item_features=None,
                 preserve_rows=False, num_threads=1):
     """
-    Measure the recall at k metric for a model: the number of positive items in the first k
-    positions of the ranked list of results divided by the number of positive items
-    in the test period. A perfect score is 1.0.
+    Measure the recall at k metric for a model: the number of positive items in
+    the first k positions of the ranked list of results divided by the number 
+    of positive items in the test period. A perfect score is 1.0.
 
     Parameters
     ----------
@@ -89,7 +90,7 @@ def recall_at_k(model, test_interactions, train_interactions=None,
          Non-zero entries representing known positives in the evaluation set.
     train_interactions: np.float32 csr_matrix of shape [n_users, n_items], optional
          Non-zero entries representing known positives in the train set. These
-         will be omitted from the score calulations to avoid re-recommending
+         will be omitted from the score calculations to avoid re-recommending
          known positives.
     k: integer, optional
          The k parameter.
@@ -98,9 +99,10 @@ def recall_at_k(model, test_interactions, train_interactions=None,
     item_features: np.float32 csr_matrix of shape [n_items, n_item_features], optional
          Each row contains that item's weights over features.
     preserve_rows: boolean, optional
-         When False (default), the number of rows in the output will be equal to
-         the number of users with interactions in the evaluation set. When True,
-         the number of rows in the output will be equal to the number of users.
+         When False (default), the number of rows in the output will be equal
+         to the number of users with interactions in the evaluation set.
+         When True, the number of rows in the output will be equal to the
+         number of users.
     num_threads: int, optional
          Number of parallel computation threads to use. Should
          not be higher than the number of physical cores.
@@ -109,8 +111,9 @@ def recall_at_k(model, test_interactions, train_interactions=None,
     -------
 
     np.array of shape [n_users with interactions or n_users,]
-         Numpy array containing recall@k scores for each user. If there are no interactions
-         for a given user having items in the test period, the returned recall will be 0.
+         Numpy array containing recall@k scores for each user. If there are no 
+         interactions for a given user having items in the test period, the 
+         returned recall will be 0.
     """
 
     ranks = model.predict_rank(test_interactions,
@@ -135,8 +138,9 @@ def auc_score(model, test_interactions, train_interactions=None,
               user_features=None, item_features=None,
               preserve_rows=False, num_threads=1):
     """
-    Measure the ROC AUC metric for a model: the probability that a randomly chosen positive
-    example has a higher score than a randomly chosen negative example.
+    Measure the ROC AUC metric for a model: the probability that a randomly 
+    chosen positive example has a higher score than a randomly chosen negative 
+    example.
     A perfect score is 1.0.
 
     Parameters
@@ -148,16 +152,17 @@ def auc_score(model, test_interactions, train_interactions=None,
          Non-zero entries representing known positives in the evaluation set.
     train_interactions: np.float32 csr_matrix of shape [n_users, n_items], optional
          Non-zero entries representing known positives in the train set. These
-         will be omitted from the score calulations to avoid re-recommending
+         will be omitted from the score calculations to avoid re-recommending
          known positives.
     user_features: np.float32 csr_matrix of shape [n_users, n_user_features], optional
          Each row contains that user's weights over features.
     item_features: np.float32 csr_matrix of shape [n_items, n_item_features], optional
          Each row contains that item's weights over features.
     preserve_rows: boolean, optional
-         When False (default), the number of rows in the output will be equal to
-         the number of users with interactions in the evaluation set. When True,
-         the number of rows in the output will be equal to the number of users.
+         When False (default), the number of rows in the output will be equal
+         to the number of users with interactions in the evaluation set.
+         When True, the number of rows in the output will be equal to the 
+         number of users.
     num_threads: int, optional
          Number of parallel computation threads to use. Should
          not be higher than the number of physical cores.
@@ -166,8 +171,8 @@ def auc_score(model, test_interactions, train_interactions=None,
     -------
 
     np.array of shape [n_users with interactions or n_users,]
-         Numpy array containing AUC scores for each user. If there are no interactions for a given
-         user the returned AUC will be 0.5.
+         Numpy array containing AUC scores for each user. If there are no
+         interactions for a given user the returned AUC will be 0.5.
     """
 
     ranks = model.predict_rank(test_interactions,
@@ -175,12 +180,14 @@ def auc_score(model, test_interactions, train_interactions=None,
                                user_features=user_features,
                                item_features=item_features,
                                num_threads=num_threads)
+
     assert np.all(ranks.data >= 0)
 
     auc = np.zeros(ranks.shape[0], dtype=np.float32)
 
     if train_interactions is not None:
-        num_train_positives = (np.squeeze(np.array(train_interactions.getnnz(axis=1))
+        num_train_positives = (np.squeeze(np.array(train_interactions
+                                                   .getnnz(axis=1))
                                           .astype(np.int32)))
     else:
         num_train_positives = np.zeros(test_interactions.shape[0],
@@ -217,16 +224,17 @@ def reciprocal_rank(model, test_interactions, train_interactions=None,
          Non-zero entries representing known positives in the evaluation set.
     train_interactions: np.float32 csr_matrix of shape [n_users, n_items], optional
          Non-zero entries representing known positives in the train set. These
-         will be omitted from the score calulations to avoid re-recommending
+         will be omitted from the score calculations to avoid re-recommending
          known positives.
     user_features: np.float32 csr_matrix of shape [n_users, n_user_features], optional
          Each row contains that user's weights over features.
     item_features: np.float32 csr_matrix of shape [n_items, n_item_features], optional
          Each row contains that item's weights over features.
     preserve_rows: boolean, optional
-         When False (default), the number of rows in the output will be equal to
-         the number of users with interactions in the evaluation set. When True,
-         the number of rows in the output will be equal to the number of users.
+         When False (default), the number of rows in the output will be equal
+         to the number of users with interactions in the evaluation set.
+         When True, the number of rows in the output will be equal to the 
+         number of users.
     num_threads: int, optional
          Number of parallel computation threads to use. Should
          not be higher than the number of physical cores.
@@ -236,7 +244,8 @@ def reciprocal_rank(model, test_interactions, train_interactions=None,
 
     np.array of shape [n_users with interactions or n_users,]
          Numpy array containing reciprocal rank scores for each user.
-         If there are no interactions for a given user the returned value will be 0.0.
+         If there are no interactions for a given user the returned value will 
+         be 0.0.
     """
 
     ranks = model.predict_rank(test_interactions,

--- a/lightfm/evaluation.py
+++ b/lightfm/evaluation.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 """
-Module containing evaluation functions suitable for judging the performance of 
+Module containing evaluation functions suitable for judging the performance of
 a fitted LightFM model.
 """
 
@@ -19,7 +19,7 @@ def precision_at_k(model, test_interactions, train_interactions=None,
                    k=10, user_features=None, item_features=None,
                    preserve_rows=False, num_threads=1):
     """
-    Measure the precision at k metric for a model: the fraction of known 
+    Measure the precision at k metric for a model: the fraction of known
     positives in the first k positions of the ranked list of results.
     A perfect score is 1.0.
 
@@ -53,7 +53,7 @@ def precision_at_k(model, test_interactions, train_interactions=None,
     -------
 
     np.array of shape [n_users with interactions or n_users,]
-         Numpy array containing precision@k scores for each user. If there are 
+         Numpy array containing precision@k scores for each user. If there are
          no interactions for a given user the returned precision will be 0.
     """
 
@@ -78,7 +78,7 @@ def recall_at_k(model, test_interactions, train_interactions=None,
                 preserve_rows=False, num_threads=1):
     """
     Measure the recall at k metric for a model: the number of positive items in
-    the first k positions of the ranked list of results divided by the number 
+    the first k positions of the ranked list of results divided by the number
     of positive items in the test period. A perfect score is 1.0.
 
     Parameters
@@ -111,8 +111,8 @@ def recall_at_k(model, test_interactions, train_interactions=None,
     -------
 
     np.array of shape [n_users with interactions or n_users,]
-         Numpy array containing recall@k scores for each user. If there are no 
-         interactions for a given user having items in the test period, the 
+         Numpy array containing recall@k scores for each user. If there are no
+         interactions for a given user having items in the test period, the
          returned recall will be 0.
     """
 
@@ -138,8 +138,8 @@ def auc_score(model, test_interactions, train_interactions=None,
               user_features=None, item_features=None,
               preserve_rows=False, num_threads=1):
     """
-    Measure the ROC AUC metric for a model: the probability that a randomly 
-    chosen positive example has a higher score than a randomly chosen negative 
+    Measure the ROC AUC metric for a model: the probability that a randomly
+    chosen positive example has a higher score than a randomly chosen negative
     example.
     A perfect score is 1.0.
 
@@ -161,7 +161,7 @@ def auc_score(model, test_interactions, train_interactions=None,
     preserve_rows: boolean, optional
          When False (default), the number of rows in the output will be equal
          to the number of users with interactions in the evaluation set.
-         When True, the number of rows in the output will be equal to the 
+         When True, the number of rows in the output will be equal to the
          number of users.
     num_threads: int, optional
          Number of parallel computation threads to use. Should
@@ -233,7 +233,7 @@ def reciprocal_rank(model, test_interactions, train_interactions=None,
     preserve_rows: boolean, optional
          When False (default), the number of rows in the output will be equal
          to the number of users with interactions in the evaluation set.
-         When True, the number of rows in the output will be equal to the 
+         When True, the number of rows in the output will be equal to the
          number of users.
     num_threads: int, optional
          Number of parallel computation threads to use. Should
@@ -244,7 +244,7 @@ def reciprocal_rank(model, test_interactions, train_interactions=None,
 
     np.array of shape [n_users with interactions or n_users,]
          Numpy array containing reciprocal rank scores for each user.
-         If there are no interactions for a given user the returned value will 
+         If there are no interactions for a given user the returned value will
          be 0.0.
     """
 

--- a/lightfm/lightfm.py
+++ b/lightfm/lightfm.py
@@ -64,7 +64,7 @@ class LightFM(object):
     user_embeddings: np.float32 array of shape [n_user_features, n_components]
          Contains the estimated latent vectors for user features. The [i, j]-th
          entry gives the value of the j-th component for the i-th user feature.
-         In the simplest case where the user feature matrix is an identity 
+         In the simplest case where the user feature matrix is an identity
          matrix, the i-th row will represent the i-th user latent vector.
     item_biases: np.float32 array of shape [n_item_features,]
          Contains the biases for item_features.
@@ -99,7 +99,7 @@ class LightFM(object):
     References
     ----------
 
-    .. [1] Rendle, Steffen, et al. "BPR: Bayesian personalized ranking from 
+    .. [1] Rendle, Steffen, et al. "BPR: Bayesian personalized ranking from
            implicit feedback."
            Proceedings of the Twenty-Fifth Conference on Uncertainty in
            Artificial Intelligence. AUAI Press, 2009.
@@ -107,7 +107,7 @@ class LightFM(object):
            to large vocabulary image annotation." IJCAI. Vol. 11. 2011.
     .. [3] Weston, Jason, Hector Yee, and Ron J. Weiss. "Learning to rank
            recommendations with the k-order statistic loss."
-           Proceedings of the 7th ACM conference on Recommender systems. ACM, 
+           Proceedings of the 7th ACM conference on Recommender systems. ACM,
            2013.
     .. [4] Duchi, John, Elad Hazan, and Yoram Singer. "Adaptive subgradient
            methods for online learning and stochastic optimization."
@@ -279,8 +279,8 @@ class LightFM(object):
 
             if not (np.array_equal(interactions.row,
                                    sample_weight.row) and
-                        np.array_equal(interactions.col,
-                                       sample_weight.col)):
+                    np.array_equal(interactions.col,
+                                   sample_weight.col)):
                 raise ValueError('Sample weight and interaction matrix '
                                  'entries must be in the same order')
 
@@ -575,7 +575,7 @@ class LightFM(object):
         ---------
 
         user_ids: integer or np.int32 array of shape [n_pairs,]
-             single user id or an array containing the user ids for the 
+             single user id or an array containing the user ids for the
              user-item pairs for which a prediction is to be computed
         item_ids: np.int32 array of shape [n_pairs,]
              an array containing the item ids for the user-item pairs for which
@@ -632,10 +632,10 @@ class LightFM(object):
     def predict_rank(self, test_interactions, train_interactions=None,
                      item_features=None, user_features=None, num_threads=1):
         """
-        Predict the rank of selected interactions. Computes recommendation 
+        Predict the rank of selected interactions. Computes recommendation
         rankings across all items for every user in interactions and calculates
         the rank of all non-zero entries in the recommendation ranking, with 0
-        meaning the top of the list (most recommended) and n_items - 1 being 
+        meaning the top of the list (most recommended) and n_items - 1 being
         the end of the list (least recommended).
 
         Performs best when only a handful of interactions need to be evaluated
@@ -725,7 +725,7 @@ class LightFM(object):
         Returns
         -------
 
-        (item_biases, item_embeddings): 
+        (item_biases, item_embeddings):
                 (np.float32 array of shape n_items,
                  np.float32 array of shape [n_items, num_components]
             Biases and latent representations for items.
@@ -783,18 +783,18 @@ class LightFM(object):
             Parameter names mapped to their values.
         """
 
-        params = {'loss':              self.loss,
+        params = {'loss': self.loss,
                   'learning_schedule': self.learning_schedule,
-                  'no_components':     self.no_components,
-                  'learning_rate':     self.learning_rate,
-                  'k':                 self.k,
-                  'n':                 self.n,
-                  'rho':               self.rho,
-                  'epsilon':           self.epsilon,
-                  'max_sampled':       self.max_sampled,
-                  'item_alpha':        self.item_alpha,
-                  'user_alpha':        self.user_alpha,
-                  'random_state':      self.random_state}
+                  'no_components': self.no_components,
+                  'learning_rate': self.learning_rate,
+                  'k': self.k,
+                  'n': self.n,
+                  'rho': self.rho,
+                  'epsilon': self.epsilon,
+                  'max_sampled': self.max_sampled,
+                  'item_alpha': self.item_alpha,
+                  'user_alpha': self.user_alpha,
+                  'random_state': self.random_state}
 
         return params
 

--- a/lightfm/lightfm.py
+++ b/lightfm/lightfm.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import print_function
 
 import numpy as np
@@ -8,9 +9,7 @@ from ._lightfm_fast import (CSRMatrix, FastLightFM,
                             fit_bpr, fit_logistic, fit_warp,
                             fit_warp_kos, predict_lightfm, predict_ranks)
 
-
 __all__ = ['LightFM']
-
 
 CYTHON_DTYPE = np.float32
 
@@ -25,18 +24,18 @@ class LightFM(object):
     no_components: int, optional
         the dimensionality of the feature latent embeddings.
     k: int, optional
-         for k-OS training, the k-th positive example will be selected from the n positive
-         examples sampled for every user.
+        for k-OS training, the k-th positive example will be selected from the
+        n positive examples sampled for every user.
     n: int, optional
-         for k-OS training, maximum number of positives sampled for each update.
+        for k-OS training, maximum number of positives sampled for each update.
     learning_schedule: string, optional
-         one of ('adagrad', 'adadelta').
+        one of ('adagrad', 'adadelta').
     loss: string, optional
-         one of  ('logistic', 'bpr', 'warp', 'warp-kos'): the loss function to use.
+        one of  ('logistic', 'bpr', 'warp', 'warp-kos'): the loss function.
     learning_rate: float, optional
-         initial learning rate for the adagrad learning schedule.
+        initial learning rate for the adagrad learning schedule.
     rho: float, optional
-         moving average coefficient for the adadelta learning schedule.
+        moving average coefficient for the adadelta learning schedule.
     epsilon: float, optional
         conditioning parameter for the adadelta learning schedule.
     item_alpha: float, optional
@@ -44,28 +43,29 @@ class LightFM(object):
     user_alpha: float, optional
         L2 penalty on user features.
     max_sampled: int, optional
-        maximum number of negative samples used during WARP fitting. It requires
-        a lot of sampling to find negative triplets for users that are already
-        well represented by the model; this can lead to very long training times
-        and overfitting. Setting this to a higher number will generally lead
-        to longer training times, but may in some cases improve accuracy.
+        maximum number of negative samples used during WARP fitting.
+        It requires a lot of sampling to find negative triplets for users that
+        are already well represented by the model; this can lead to very long
+        training times and overfitting. Setting this to a higher number will
+        generally lead to longer training times, but may in some cases improve
+        accuracy.
     random_state: int seed, RandomState instance, or None
-        The seed of the pseudo random number generator to use when shuffling the data and
-        initializing the parameters.
+        The seed of the pseudo random number generator to use when shuffling
+        the data and initializing the parameters.
 
     Attributes
     ----------
 
     item_embeddings: np.float32 array of shape [n_item_features, n_components]
-         Contains the estimated latent vectors for item features. The [i, j]-th entry
-         gives the value of the j-th component for the i-th item feature. In the simplest
-         case where the item feature matrix is an identity matrix, the i-th row
-         will represent the i-th item latent vector.
+         Contains the estimated latent vectors for item features. The [i, j]-th
+         entry gives the value of the j-th component for the i-th item feature.
+         In the simplest case where the item feature matrix is an identity
+         matrix, the i-th row will represent the i-th item latent vector.
     user_embeddings: np.float32 array of shape [n_user_features, n_components]
-         Contains the estimated latent vectors for user features. The [i, j]-th entry
-         gives the value of the j-th component for the i-th user feature. In the simplest
-         case where the user feature matrix is an identity matrix, the i-th row
-         will represent the i-th user latent vector.
+         Contains the estimated latent vectors for user features. The [i, j]-th
+         entry gives the value of the j-th component for the i-th user feature.
+         In the simplest case where the user feature matrix is an identity 
+         matrix, the i-th row will represent the i-th user latent vector.
     item_biases: np.float32 array of shape [n_item_features,]
          Contains the biases for item_features.
     user_biases: np.float32 array of shape [n_user_features,]
@@ -87,8 +87,9 @@ class LightFM(object):
       examples until rank violating one is found. Useful when only
       positive interactions are present and optimising the top of
       the recommendation list (precision@k) is desired.
-    - k-OS WARP: k-th order statistic loss [3]_. A modification of WARP that uses the k-th
-      positive example for any given user as a basis for pairwise updates.
+    - k-OS WARP: k-th order statistic loss [3]_. A modification of WARP that
+      uses the k-th positive example for any given user as a basis for pairwise
+      updates.
 
     Two learning rate schedules are available:
 
@@ -98,16 +99,18 @@ class LightFM(object):
     References
     ----------
 
-    .. [1] Rendle, Steffen, et al. "BPR: Bayesian personalized ranking from implicit feedback."
-           Proceedings of the Twenty-Fifth Conference on Uncertainty in Artificial
-           Intelligence. AUAI Press, 2009.
-    .. [2] Weston, Jason, Samy Bengio, and Nicolas Usunier. "Wsabie: Scaling up to large
-           vocabulary image annotation." IJCAI. Vol. 11. 2011.
-    .. [3] Weston, Jason, Hector Yee, and Ron J. Weiss. "Learning to rank recommendations with
-           the k-order statistic loss."
-           Proceedings of the 7th ACM conference on Recommender systems. ACM, 2013.
-    .. [4] Duchi, John, Elad Hazan, and Yoram Singer. "Adaptive subgradient methods
-           for online learning and stochastic optimization."
+    .. [1] Rendle, Steffen, et al. "BPR: Bayesian personalized ranking from 
+           implicit feedback."
+           Proceedings of the Twenty-Fifth Conference on Uncertainty in
+           Artificial Intelligence. AUAI Press, 2009.
+    .. [2] Weston, Jason, Samy Bengio, and Nicolas Usunier. "Wsabie: Scaling up
+           to large vocabulary image annotation." IJCAI. Vol. 11. 2011.
+    .. [3] Weston, Jason, Hector Yee, and Ron J. Weiss. "Learning to rank
+           recommendations with the k-order statistic loss."
+           Proceedings of the 7th ACM conference on Recommender systems. ACM, 
+           2013.
+    .. [4] Duchi, John, Elad Hazan, and Yoram Singer. "Adaptive subgradient
+           methods for online learning and stochastic optimization."
            The Journal of Machine Learning Research 12 (2011): 2121-2159.
     .. [5] Zeiler, Matthew D. "ADADELTA: An adaptive learning rate method."
            arXiv preprint arXiv:1212.5701 (2012).
@@ -180,8 +183,9 @@ class LightFM(object):
         """
 
         # Initialise item features.
-        self.item_embeddings = ((self.random_state.rand(no_item_features, no_components) - 0.5) /
-                                no_components).astype(np.float32)
+        self.item_embeddings = (
+            (self.random_state.rand(no_item_features, no_components) - 0.5) /
+            no_components).astype(np.float32)
         self.item_embedding_gradients = np.zeros_like(self.item_embeddings)
         self.item_embedding_momentum = np.zeros_like(self.item_embeddings)
         self.item_biases = np.zeros(no_item_features, dtype=np.float32)
@@ -189,8 +193,9 @@ class LightFM(object):
         self.item_bias_momentum = np.zeros_like(self.item_biases)
 
         # Initialise user features.
-        self.user_embeddings = ((self.random_state.rand(no_user_features, no_components) - 0.5) /
-                                no_components).astype(np.float32)
+        self.user_embeddings = (
+            (self.random_state.rand(no_user_features, no_components) - 0.5) /
+            no_components).astype(np.float32)
         self.user_embedding_gradients = np.zeros_like(self.user_embeddings)
         self.user_embedding_momentum = np.zeros_like(self.user_embeddings)
         self.user_biases = np.zeros(no_user_features, dtype=np.float32)
@@ -274,8 +279,8 @@ class LightFM(object):
 
             if not (np.array_equal(interactions.row,
                                    sample_weight.row) and
-                    np.array_equal(interactions.col,
-                                   sample_weight.col)):
+                        np.array_equal(interactions.col,
+                                       sample_weight.col)):
                 raise ValueError('Sample weight and interaction matrix '
                                  'entries must be in the same order')
 
@@ -329,8 +334,8 @@ class LightFM(object):
             # large boolean temporary.
             if not np.isfinite(np.sum(parameter)):
                 raise ValueError("Not all estimated parameters are finite, "
-                                 "your model may have diverged. Try decreasing "
-                                 "the learning rate.")
+                                 "your model may have diverged. Try decreasing"
+                                 " the learning rate.")
 
     def fit(self, interactions,
             user_features=None, item_features=None,
@@ -355,7 +360,7 @@ class LightFM(object):
              interactions from the interactions matrix.
              Its row and col arrays must be the same as
              those of the interactions matrix. For memory
-             efficiency its ssible to use the same arrays
+             efficiency its possible to use the same arrays
              for both weights and interaction matrices.
              Defaults to weight 1.0 for all interactions.
              Not implemented for the k-OS loss.
@@ -394,7 +399,7 @@ class LightFM(object):
         Fit the model.
 
         Fit the model. Unlike fit, repeated calls to this method will
-        cause trainig to resume from the current model state.
+        cause training to resume from the current model state.
 
         Arguments
         ---------
@@ -412,7 +417,7 @@ class LightFM(object):
              interactions from the interactions matrix.
              Its row and col arrays must be the same as
              those of the interactions matrix. For memory
-             efficiency its ssible to use the same arrays
+             efficiency its possible to use the same arrays
              for both weights and interaction matrices.
              Defaults to weight 1.0 for all interactions.
              Not implemented for the k-OS loss.
@@ -493,7 +498,8 @@ class LightFM(object):
         if loss in ('warp', 'bpr', 'warp-kos'):
             # The CSR conversion needs to happen before shuffle indices are created.
             # Calling .tocsr may result in a change in the data arrays of the COO matrix,
-            positives_lookup = CSRMatrix(self._get_positives_lookup_matrix(interactions))
+            positives_lookup = CSRMatrix(
+                self._get_positives_lookup_matrix(interactions))
 
         # Create shuffle indexes.
         shuffle_indices = np.arange(len(interactions.data), dtype=np.int32)
@@ -560,7 +566,8 @@ class LightFM(object):
                          self.user_alpha,
                          num_threads)
 
-    def predict(self, user_ids, item_ids, item_features=None, user_features=None, num_threads=1):
+    def predict(self, user_ids, item_ids, item_features=None,
+                user_features=None, num_threads=1):
         """
         Compute the recommendation score for user-item pairs.
 
@@ -568,8 +575,8 @@ class LightFM(object):
         ---------
 
         user_ids: integer or np.int32 array of shape [n_pairs,]
-             single user id or an array containing the user ids for the user-item pairs for which
-             a prediction is to be computed
+             single user id or an array containing the user ids for the 
+             user-item pairs for which a prediction is to be computed
         item_ids: np.int32 array of shape [n_pairs,]
              an array containing the item ids for the user-item pairs for which
              a prediction is to be computed.
@@ -585,7 +592,8 @@ class LightFM(object):
         -------
 
         np.float32 array of shape [n_pairs,]
-            Numpy array containig the recommendation scores for pairs defined by the inputs.
+            Numpy array containing the recommendation scores for pairs defined
+            by the inputs.
         """
 
         if not isinstance(user_ids, np.ndarray):
@@ -624,39 +632,42 @@ class LightFM(object):
     def predict_rank(self, test_interactions, train_interactions=None,
                      item_features=None, user_features=None, num_threads=1):
         """
-        Predict the rank of selected interactions. Computes recommendation rankings across all items
-        for every user in interactions and calculates the rank of all non-zero entries
-        in the recommendation ranking, with 0 meaning the top of the list (most recommended)
-        and n_items - 1 being the end of the list (least recommended).
+        Predict the rank of selected interactions. Computes recommendation 
+        rankings across all items for every user in interactions and calculates
+        the rank of all non-zero entries in the recommendation ranking, with 0
+        meaning the top of the list (most recommended) and n_items - 1 being 
+        the end of the list (least recommended).
 
-        Performs best when only a handful of interactions need to be evaluated per user. If you
-        need to compute predictions for many items for every user, use the predict method instead.
+        Performs best when only a handful of interactions need to be evaluated
+        per user. If you need to compute predictions for many items for every
+        user, use the predict method instead.
 
         Arguments
         ---------
 
         test_interactions: np.float32 csr_matrix of shape [n_users, n_items]
-             Non-zero entries denote the user-item pairs whose rank will be computed.
+             Non-zero entries denote the user-item pairs
+             whose rank will be computed.
         train_interactions: np.float32 csr_matrix of shape [n_users, n_items], optional
-             Non-zero entries denote the user-item pairs which will be excluded from
-             rank computation. Use to exclude training set interactions from being scored
-             and ranked for evaluation.
+             Non-zero entries denote the user-item pairs which will be excluded
+             from rank computation. Use to exclude training set interactions
+             from being scored and ranked for evaluation.
         user_features: np.float32 csr_matrix of shape [n_users, n_user_features], optional
              Each row contains that user's weights over features.
         item_features: np.float32 csr_matrix of shape [n_items, n_item_features], optional
              Each row contains that item's weights over features.
         num_threads: int, optional
-             Number of parallel computation threads to use. Should
-             not be higher than the number of physical cores.
+             Number of parallel computation threads to use.
+             Should not be higher than the number of physical cores.
 
         Returns
         -------
 
         np.float32 csr_matrix of shape [n_users, n_items]
-            the [i, j]-th entry of the matrix will contain the rank of the j-th item
-            in the sorted recommendations list for the i-th user. The degree
-            of sparsity of this matrix will be equal to that of the input interactions
-            matrix.
+            the [i, j]-th entry of the matrix will contain the rank of the j-th
+            item in the sorted recommendations list for the i-th user.
+            The degree of sparsity of this matrix will be equal to that of the
+            input interactions matrix.
         """
 
         n_users, n_items = test_interactions.shape
@@ -714,8 +725,9 @@ class LightFM(object):
         Returns
         -------
 
-        (item_biases, item_embeddings): (np.float32 array of shape n_items
-                                         np.float32 array of shape [n_items, num_components]
+        (item_biases, item_embeddings): 
+                (np.float32 array of shape n_items,
+                 np.float32 array of shape [n_items, num_components]
             Biases and latent representations for items.
         """
 
@@ -740,8 +752,9 @@ class LightFM(object):
         Returns
         -------
 
-        (user_biases, user_embeddings): (np.float32 array of shape n_users
-                                         np.float32 array of shape [n_users, num_components]
+        (user_biases, user_embeddings):
+                (np.float32 array of shape n_users
+                 np.float32 array of shape [n_users, num_components]
             Biases and latent representations for users.
         """
 
@@ -770,18 +783,18 @@ class LightFM(object):
             Parameter names mapped to their values.
         """
 
-        params = {'loss': self.loss,
+        params = {'loss':              self.loss,
                   'learning_schedule': self.learning_schedule,
-                  'no_components': self.no_components,
-                  'learning_rate': self.learning_rate,
-                  'k': self.k,
-                  'n': self.n,
-                  'rho': self.rho,
-                  'epsilon': self.epsilon,
-                  'max_sampled': self.max_sampled,
-                  'item_alpha': self.item_alpha,
-                  'user_alpha': self.user_alpha,
-                  'random_state': self.random_state}
+                  'no_components':     self.no_components,
+                  'learning_rate':     self.learning_rate,
+                  'k':                 self.k,
+                  'n':                 self.n,
+                  'rho':               self.rho,
+                  'epsilon':           self.epsilon,
+                  'max_sampled':       self.max_sampled,
+                  'item_alpha':        self.item_alpha,
+                  'user_alpha':        self.user_alpha,
+                  'random_state':      self.random_state}
 
         return params
 

--- a/setup.py
+++ b/setup.py
@@ -142,8 +142,7 @@ class PyTest(TestCommand):
         sys.exit(errno)
 
 
-use_openmp = (not (sys.platform.startswith('darwin')
-                   or sys.platform.startswith('win')))
+use_openmp = not sys.platform.startswith('darwin') and not sys.platform.startswith('win')
 
 setup(
     name='lightfm',

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 import os
 import subprocess
 import sys
@@ -12,7 +13,6 @@ from lightfm import __version__ as version  # NOQA
 
 
 def define_extensions(use_openmp):
-
     compile_args = ['-ffast-math']
 
     # There are problems with illegal ASM instructions
@@ -49,7 +49,6 @@ class Cythonize(Command):
         pass
 
     def generate_pyx(self):
-
         openmp_import = textwrap.dedent("""
              from cython.parallel import parallel, prange
              cimport openmp
@@ -84,11 +83,11 @@ class Cythonize(Command):
 
         for variant, template_params in params:
             with open(os.path.join(file_dir,
-                                   '_lightfm_fast_{}.pyx'.format(variant)), 'w') as fl:
+                                   '_lightfm_fast_{}.pyx'.format(variant)),
+                      'w') as fl:
                 fl.write(template.format(**template_params))
 
     def run(self):
-
         from Cython.Build import cythonize
 
         self.generate_pyx()
@@ -114,13 +113,14 @@ class Clean(Command):
         pass
 
     def run(self):
-
         pth = os.path.dirname(os.path.abspath(__file__))
 
         subprocess.call(['rm', '-rf', os.path.join(pth, 'build')])
         subprocess.call(['rm', '-rf', os.path.join(pth, 'lightfm.egg-info')])
-        subprocess.call(['find', pth, '-name', 'lightfm*.pyc', '-type', 'f', '-delete'])
-        subprocess.call(['rm', os.path.join(pth, 'lightfm', '_lightfm_fast.so')])
+        subprocess.call(
+            ['find', pth, '-name', 'lightfm*.pyc', '-type', 'f', '-delete'])
+        subprocess.call(
+            ['rm', os.path.join(pth, 'lightfm', '_lightfm_fast.so')])
 
 
 class PyTest(TestCommand):
@@ -142,8 +142,8 @@ class PyTest(TestCommand):
         sys.exit(errno)
 
 
-use_openmp = not (sys.platform.startswith('darwin') or sys.platform.startswith('win'))
-
+use_openmp = (not (sys.platform.startswith('darwin')
+                   or sys.platform.startswith('win')))
 
 setup(
     name='lightfm',


### PR DESCRIPTION
Hi,

I reformatted the docstrings / some long code lines, so it follows the Python style standard (<79).
Now I can split my editor and still read (almost) everything without horizontal scrolling, also PyCharm doesn't cry about it anymore. I kept some long lines unchanged, because they were more readable that way.

Also fixed some typos and added utf-8 comments.

Btw I enjoy using your library, keep up the good work! Although I've got some concerns about the validity of the tests, because at first glance it doesn't seem to separate the features, so the tests are only valid when checked in an interaction-only scenario. I'd be glad to work out some solution / open an issue if that's the case. Of course: correct me if I'm wrong.

Best regards,
Mice Pápai