### PR TITLE
build with pybuild

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -104,10 +104,12 @@ class Clean(Command):
     Clean build files.
     """
 
-    user_options = []
+    user_options = [
+        ('all', None, '(Compatibility with original clean command)')
+    ]
 
     def initialize_options(self):
-        pass
+        self.all = False
 
     def finalize_options(self):
         pass


### PR DESCRIPTION
Fix error:

```
dh clean --with python2,python3 --buildsystem=pybuild
   dh_testdir -O--buildsystem=pybuild
   dh_auto_clean -O--buildsystem=pybuild
I: pybuild base:170: python2.7 setup.py clean 
running clean
error: error in /home/atikunov/build/trusty/python-lightfm/deb_dist/lightfm-1.13/.pybuild/pythonX.Y_2.7/.pydistutils.cfg: command 'Clean' has no such option 'all'
E: pybuild pybuild:256: clean: plugin distutils failed with: exit code=1: python2.7 setup.py clean
```