### PR TITLE
Make Movielens code robust to corrupted downloads.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,8 @@
 ### Changed
 - LightFM model now raises a ValueError (instead of assertion) when the number of supplied
   features exceeds the number of estimated feature embeddings.
+- Warn and delete downloaded file when Movielens download is corrputed. This happens in the wild
+  cofuses users terribly.
 
 ## [1.13][2017-05-20]
 ### Added

--- a/lightfm/datasets/movielens.py
+++ b/lightfm/datasets/movielens.py
@@ -1,4 +1,5 @@
 import itertools
+import os
 import zipfile
 
 import numpy as np
@@ -165,8 +166,16 @@ def fetch_movielens(data_home=None, indicator_features=True, genre_features=Fals
                                 download_if_missing)
 
     # Load raw data
-    (train_raw, test_raw,
-     item_metadata_raw, genres_raw) = _read_raw_data(zip_path)
+    try:
+        (train_raw, test_raw,
+         item_metadata_raw, genres_raw) = _read_raw_data(zip_path)
+    except zipfile.BadZipFile:
+        # Download was corrupted, get rid of the partially
+        # downloaded file so that we re-download on the
+        # next try.
+        os.unlink(zip_path)
+        raise ValueError('Corrupted Movielens download. Check your '
+                         'internet connection and try again.')
 
     # Figure out the dimensions
     num_users, num_items = _get_dimensions(_parse(train_raw),


### PR DESCRIPTION
Handles https://github.com/lyst/lightfm/issues/134 and https://stackoverflow.com/questions/46138406/build-error-if-you-try-to-use-lightfm-data-sets.