### PR TITLE
Check that the inputs passed do not overflow.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## [unreleased][unreleased]
 ### Fixed
 - Fixed error message when item features have the wrong dimensions.
+- Predict now checks for overflow in inputs to predict.
 
 ## [1.14][2017-11-18]
 ### Added

--- a/lightfm/lightfm.py
+++ b/lightfm/lightfm.py
@@ -696,12 +696,20 @@ class LightFM(object):
         if not isinstance(user_ids, np.ndarray):
             user_ids = np.repeat(np.int32(user_ids), len(item_ids))
 
+        if isinstance(item_ids, (list, tuple)):
+            item_ids = np.array(item_ids, dtype=np.int32)
+
         assert len(user_ids) == len(item_ids)
 
         if user_ids.dtype != np.int32:
             user_ids = user_ids.astype(np.int32)
         if item_ids.dtype != np.int32:
             item_ids = item_ids.astype(np.int32)
+
+        if user_ids.min() < 0 or item_ids.min() < 0:
+            raise ValueError('User or item ids cannot be negative. '
+                             'Check your inputs for negative numbers '
+                             'or very large numbers that can overflow.')
 
         n_users = user_ids.max() + 1
         n_items = item_ids.max() + 1

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -378,3 +378,19 @@ def test_nan_interactions():
 
     with pytest.raises(ValueError):
         model.fit(train)
+
+
+def test_overflow_predict():
+
+    no_users, no_items = (1000, 1000)
+
+    train = sp.rand(no_users, no_items, format='csr', random_state=42)
+
+    model = LightFM(loss='warp')
+
+    model.fit(train)
+
+    with pytest.raises((ValueError, OverflowError)):
+        print(model.predict(1231241241231241414,
+                            np.arange(no_items),
+                            user_features=sp.identity(no_users)))


### PR DESCRIPTION
Apparently it's possible to pass in inputs so _spectacularly_ wrong as
to make int32s overflow and segfault the indexing code.