### PR TITLE
Don't use astype on the sparse weights matrix.

### DIFF
--- a/lightfm/lightfm.py
+++ b/lightfm/lightfm.py
@@ -540,15 +540,10 @@ class LightFM(object):
                                                            user_features,
                                                            item_features)
 
-        sample_weight = (self._to_cython_dtype(sample_weight)
-                         if sample_weight is not None else
-                         np.ones(interactions.getnnz(),
-                                 dtype=CYTHON_DTYPE))
-
         for input_data in (user_features.data,
                            item_features.data,
                            interactions.data,
-                           sample_weight):
+                           sample_weight_data):
             self._check_input_finite(input_data)
         if self.item_embeddings is None:
             # Initialise latent factors only if this is the first call

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -39,6 +39,7 @@ def test_matrix_types():
             train = mattype((no_users,
                              no_items),
                             dtype=dtype)
+            weights = train.tocoo()
 
             user_features = mattype((no_users,
                                      no_features),
@@ -49,6 +50,7 @@ def test_matrix_types():
 
             model = LightFM()
             model.fit_partial(train,
+                              sample_weight=weights,
                               user_features=user_features,
                               item_features=item_features)
 


### PR DESCRIPTION
Doing so can change the order of the
entries (https://github.com/lyst/lightfm/issues/272) for details.