### PR TITLE
Adding an optional check for intersections between test and train matrices in predict_rank().

### DIFF
--- a/lightfm/evaluation.py
+++ b/lightfm/evaluation.py
@@ -17,7 +17,7 @@ __all__ = ['precision_at_k',
 
 def precision_at_k(model, test_interactions, train_interactions=None,
                    k=10, user_features=None, item_features=None,
-                   preserve_rows=False, num_threads=1):
+                   preserve_rows=False, num_threads=1, check_intersections=True):
     """
     Measure the precision at k metric for a model: the fraction of known
     positives in the first k positions of the ranked list of results.
@@ -48,6 +48,10 @@ def precision_at_k(model, test_interactions, train_interactions=None,
     num_threads: int, optional
          Number of parallel computation threads to use. Should
          not be higher than the number of physical cores.
+    check_intersections: bool, optional, True by default,
+        Only relevant when train_interactions are supplied.
+        A flag that signals whether the test and train matrices should be checked
+        for intersections to prevent optimistic ranks / wrong evaluation / bad data split.
 
     Returns
     -------
@@ -61,7 +65,9 @@ def precision_at_k(model, test_interactions, train_interactions=None,
                                train_interactions=train_interactions,
                                user_features=user_features,
                                item_features=item_features,
-                               num_threads=num_threads)
+                               num_threads=num_threads,
+                               check_intersections=check_intersections,
+                               )
 
     ranks.data = np.less(ranks.data, k, ranks.data)
 
@@ -75,7 +81,7 @@ def precision_at_k(model, test_interactions, train_interactions=None,
 
 def recall_at_k(model, test_interactions, train_interactions=None,
                 k=10, user_features=None, item_features=None,
-                preserve_rows=False, num_threads=1):
+                preserve_rows=False, num_threads=1, check_intersections=True):
     """
     Measure the recall at k metric for a model: the number of positive items in
     the first k positions of the ranked list of results divided by the number
@@ -106,6 +112,10 @@ def recall_at_k(model, test_interactions, train_interactions=None,
     num_threads: int, optional
          Number of parallel computation threads to use. Should
          not be higher than the number of physical cores.
+    check_intersections: bool, optional, True by default,
+        Only relevant when train_interactions are supplied.
+        A flag that signals whether the test and train matrices should be checked
+        for intersections to prevent optimistic ranks / wrong evaluation / bad data split.
 
     Returns
     -------
@@ -120,7 +130,9 @@ def recall_at_k(model, test_interactions, train_interactions=None,
                                train_interactions=train_interactions,
                                user_features=user_features,
                                item_features=item_features,
-                               num_threads=num_threads)
+                               num_threads=num_threads,
+                               check_intersections=check_intersections,
+                               )
 
     ranks.data = np.less(ranks.data, k, ranks.data)
 
@@ -136,7 +148,7 @@ def recall_at_k(model, test_interactions, train_interactions=None,
 
 def auc_score(model, test_interactions, train_interactions=None,
               user_features=None, item_features=None,
-              preserve_rows=False, num_threads=1):
+              preserve_rows=False, num_threads=1, check_intersections=True):
     """
     Measure the ROC AUC metric for a model: the probability that a randomly
     chosen positive example has a higher score than a randomly chosen negative
@@ -166,6 +178,10 @@ def auc_score(model, test_interactions, train_interactions=None,
     num_threads: int, optional
          Number of parallel computation threads to use. Should
          not be higher than the number of physical cores.
+    check_intersections: bool, optional, True by default,
+        Only relevant when train_interactions are supplied.
+        A flag that signals whether the test and train matrices should be checked
+        for intersections to prevent optimistic ranks / wrong evaluation / bad data split.
 
     Returns
     -------
@@ -179,7 +195,9 @@ def auc_score(model, test_interactions, train_interactions=None,
                                train_interactions=train_interactions,
                                user_features=user_features,
                                item_features=item_features,
-                               num_threads=num_threads)
+                               num_threads=num_threads,
+                               check_intersections=check_intersections,
+                               )
 
     assert np.all(ranks.data >= 0)
 
@@ -210,7 +228,7 @@ def auc_score(model, test_interactions, train_interactions=None,
 
 def reciprocal_rank(model, test_interactions, train_interactions=None,
                     user_features=None, item_features=None,
-                    preserve_rows=False, num_threads=1):
+                    preserve_rows=False, num_threads=1, check_intersections=True):
     """
     Measure the reciprocal rank metric for a model: 1 / the rank of the highest
     ranked positive example. A perfect score is 1.0.
@@ -238,6 +256,10 @@ def reciprocal_rank(model, test_interactions, train_interactions=None,
     num_threads: int, optional
          Number of parallel computation threads to use. Should
          not be higher than the number of physical cores.
+    check_intersections: bool, optional, True by default,
+        Only relevant when train_interactions are supplied.
+        A flag that signals whether the test and train matrices should be checked
+        for intersections to prevent optimistic ranks / wrong evaluation / bad data split.
 
     Returns
     -------
@@ -252,7 +274,9 @@ def reciprocal_rank(model, test_interactions, train_interactions=None,
                                train_interactions=train_interactions,
                                user_features=user_features,
                                item_features=item_features,
-                               num_threads=num_threads)
+                               num_threads=num_threads,
+                               check_intersections=check_intersections,
+                               )
 
     ranks.data = 1.0 / (ranks.data + 1.0)
 

--- a/lightfm/lightfm.py
+++ b/lightfm/lightfm.py
@@ -775,9 +775,10 @@ class LightFM(object):
         num_threads: int, optional
              Number of parallel computation threads to use.
              Should not be higher than the number of physical cores.
-        check_intersections: bool, optional, True by default
-             A flag that signals whether the input matrices should be checked for intersections.
-             This is to prevent optimistic ranks and methodologically wrong evaluation.
+        check_intersections: bool, optional, True by default,
+            Only relevant when train_interactions are supplied.
+            A flag that signals whether the test and train matrices should be checked
+            for intersections to prevent optimistic ranks / wrong evaluation / bad data split.
 
         Returns
         -------

--- a/lightfm/lightfm.py
+++ b/lightfm/lightfm.py
@@ -734,8 +734,7 @@ class LightFM(object):
 
     def _check_test_train_intersections(self, test_mat, train_mat):
         if train_mat is not None:
-            bool_intersections_mat = test_mat.astype(bool).multiply(train_mat.astype(bool))
-            n_intersections = np.sum(bool_intersections_mat.tocsr().data)
+            n_intersections = test_mat.multiply(train_mat).nnz
             if n_intersections:
                 raise ValueError(
                     'Test interactions matrix and train interactions '

--- a/lightfm/lightfm.py
+++ b/lightfm/lightfm.py
@@ -732,8 +732,19 @@ class LightFM(object):
 
         return predictions
 
+    def _check_test_train_intersections(self, test_mat, train_mat):
+        if train_mat is not None:
+            bool_intersections_mat = test_mat.astype(bool).multiply(train_mat.astype(bool))
+            n_intersections = np.sum(bool_intersections_mat.tocsr().data)
+            if n_intersections:
+                raise ValueError(
+                    'Test interactions matrix and train interactions '
+                    'matrix share %d interactions. This will cause '
+                    'incorrect evaluation, check your data split.' % n_intersections)
+
     def predict_rank(self, test_interactions, train_interactions=None,
-                     item_features=None, user_features=None, num_threads=1):
+                     item_features=None, user_features=None, num_threads=1,
+                     check_intersections=True):
         """
         Predict the rank of selected interactions. Computes recommendation
         rankings across all items for every user in interactions and calculates
@@ -765,6 +776,9 @@ class LightFM(object):
         num_threads: int, optional
              Number of parallel computation threads to use.
              Should not be higher than the number of physical cores.
+        check_intersections: bool, optional, True by default
+             A flag that signals whether the input matrices should be checked for intersections.
+             This is to prevent optimistic ranks and methodologically wrong evaluation.
 
         Returns
         -------
@@ -777,6 +791,9 @@ class LightFM(object):
         """
 
         self._check_initialized()
+
+        if check_intersections:
+            self._check_test_train_intersections(test_interactions, train_interactions)
 
         n_users, n_items = test_interactions.shape
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -292,15 +292,16 @@ def test_predict_ranks():
 
     # check error is raised when train and test have interactions in common
     with pytest.raises(ValueError):
-        model.predict_rank(
-            train, train_interactions=train, check_intersections=True).todense()
+        model.predict_rank(train, train_interactions=train, check_intersections=True)
+
+    # check error not raised when flag is False
+    model.predict_rank(train, train_interactions=train, check_intersections=False)
 
     # check no errors raised when train and test have no interactions in common
     not_train = sp.rand(no_users, no_items, format='csr', random_state=43) - train
     not_train.data[not_train.data < 0] = 0
     not_train.eliminate_zeros()
-    model.predict_rank(
-        not_train, train_interactions=train, check_intersections=True).todense()
+    model.predict_rank(not_train, train_interactions=train, check_intersections=True)
 
     # Make sure ranks are computed pessimistically when
     # there are ties (that is, equal predictions for every

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -292,14 +292,14 @@ def test_predict_ranks():
 
     # check error is raised when train and test have interactions in common
     with pytest.raises(ValueError):
-        _ = model.predict_rank(
+        model.predict_rank(
             train, train_interactions=train, check_intersections=True).todense()
 
     # check no errors raised when train and test have no interactions in common
     not_train = sp.rand(no_users, no_items, format='csr', random_state=43) - train
     not_train.data[not_train.data < 0] = 0
     not_train.eliminate_zeros()
-    _ = model.predict_rank(
+    model.predict_rank(
         not_train, train_interactions=train, check_intersections=True).todense()
 
     # Make sure ranks are computed pessimistically when

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -279,16 +279,28 @@ def test_predict_ranks():
 
     # Train set exclusions. All ranks should be zero
     # if train interactions is dense.
-    ranks = model.predict_rank(rank_input,
-                               train_interactions=rank_input).todense()
+    ranks = model.predict_rank(
+        rank_input, train_interactions=rank_input, check_intersections=False).todense()
     assert np.all(ranks == 0)
 
     # Max rank should be num_items - 1 - number of positives
     # in train in that row
-    ranks = model.predict_rank(rank_input,
-                               train_interactions=train).todense()
+    ranks = model.predict_rank(
+        rank_input, train_interactions=train, check_intersections=False).todense()
     assert np.all(np.squeeze(np.array(ranks.max(axis=1))) ==
                   no_items - 1 - np.squeeze(np.array(train.getnnz(axis=1))))
+
+    # check error is raised when train and test have interactions in common
+    with pytest.raises(ValueError):
+        _ = model.predict_rank(
+            train, train_interactions=train, check_intersections=True).todense()
+
+    # check no errors raised when train and test have no interactions in common
+    not_train = sp.rand(no_users, no_items, format='csr', random_state=43) - train
+    not_train.data[not_train.data < 0] = 0
+    not_train.eliminate_zeros()
+    _ = model.predict_rank(
+        not_train, train_interactions=train, check_intersections=True).todense()
 
     # Make sure ranks are computed pessimistically when
     # there are ties (that is, equal predictions for every


### PR DESCRIPTION
As discussed in[ this issue.](https://github.com/lyst/lightfm/issues/287)