### PR TITLE
Fix indentation to correct Sphinx formatting.

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,3 +3,5 @@ requests
 numpy
 scipy>=0.17.0
 scikit-learn
+sphinx
+sphinx_rtd_theme

--- a/lightfm/data.py
+++ b/lightfm/data.py
@@ -417,8 +417,7 @@ class Dataset(object):
         Returns
         -------
 
-        mappings: (user id map, user feature map,
-                   item id map, item id map)
+        (user id map, user feature map, item id map, item id map): tuple of dictionaries
         """
 
         return (


### PR DESCRIPTION
Fix indentation in Dataset docs. Included sphinx and sphinx_rtd_theme in requirements so that documents can build without issues.

Addresses issue: https://github.com/lyst/lightfm/issues/327