### PR TITLE
Sum duplicates in stackexchange serialized dataset

### DIFF
--- a/lightfm/datasets/stackexchange.py
+++ b/lightfm/datasets/stackexchange.py
@@ -107,6 +107,8 @@ def fetch_stackexchange(
         ),
         shape=data["interactions_shape"].flatten(),
     )
+    interactions.sum_duplicates()
+
     tag_features_mat = sp.coo_matrix(
         (data["features_data"], (data["features_row"], data["features_col"])),
         shape=data["features_shape"].flatten(),


### PR DESCRIPTION
Sum duplicate coordinates in the serialized stackexchange dataset to prevent duplicate interactions in test and train. Fixes https://github.com/lyst/lightfm/issues/421