### PR TITLE
Doc-fix: correct return value of mapping

### DIFF
--- a/lightfm/data.py
+++ b/lightfm/data.py
@@ -434,7 +434,7 @@ class Dataset(object):
         Returns
         -------
 
-        (user id map, user feature map, item id map, item id map): tuple of dictionaries
+        (user id map, user feature map, item id map, item feature map): tuple of dictionaries
         """
 
         return (


### PR DESCRIPTION
Fix the return values of the Dataset.mapping() function in documentation