### PR TITLE
Require scikit-learn dependency not just for tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -155,7 +155,7 @@ setup(
     packages=['lightfm',
               'lightfm.datasets'],
     package_data={'': ['*.c']},
-    install_requires=['numpy', 'scipy>=0.17.0', 'requests'],
+    install_requires=['numpy', 'scipy>=0.17.0', 'requests', 'scikit-learn'],
     tests_require=['pytest', 'requests', 'scikit-learn'],
     cmdclass={'test': PyTest, 'cythonize': Cythonize, 'clean': Clean},
     author='Lyst Ltd (Maciej Kula)',


### PR DESCRIPTION
This PR fixes an issue caused by requiring `scikit-learn` only for the tests.

`scikit-learn` is indeed used in the tests, but it is also required in the `lightfm.data` module. However, `scikit-learn` is a requirement only for tests and not for `lightfm`.

For example, end users, who install the package through PyPI, will face a `ModuleNotFoundError` when trying to import `lightfm.data`.

```python
>>> from lightfm.data import Dataset
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/davide.sarra/.pyenv/versions/lfm/lib/python3.6/site-packages/lightfm/data.py", line 7, in <module>
    import sklearn.preprocessing
ModuleNotFoundError: No module named 'sklearn'
```