### PR TITLE
Predict with ndarrays/int only

### DIFF
--- a/lightfm/lightfm.py
+++ b/lightfm/lightfm.py
@@ -786,7 +786,9 @@ class LightFM(object):
 
         if not isinstance(user_ids, np.ndarray):
             raise TypeError(
-                f"Invalid type passed to user_ids parameter. This must be either int or np.int32 array. Type received: {type(user_ids)}"
+                f"Invalid type passed to user_ids parameter. "
+                f"This must be either int or np.int32 array. "
+                f"Type received: {type(user_ids)}"
             )
 
         if isinstance(item_ids, (list, tuple)):

--- a/lightfm/lightfm.py
+++ b/lightfm/lightfm.py
@@ -781,7 +781,7 @@ class LightFM(object):
 
         self._check_initialized()
 
-        if not isinstance(user_ids, np.ndarray) and isinstance(user_ids, int):
+        if isinstance(user_ids, int):
             user_ids = np.repeat(np.int32(user_ids), len(item_ids))
 
         assert isinstance(user_ids, np.ndarray)

--- a/lightfm/lightfm.py
+++ b/lightfm/lightfm.py
@@ -784,7 +784,10 @@ class LightFM(object):
         if isinstance(user_ids, int):
             user_ids = np.repeat(np.int32(user_ids), len(item_ids))
 
-        assert isinstance(user_ids, np.ndarray)
+        if not isinstance(user_ids, np.ndarray):
+            raise TypeError(
+                f"Invalid type passed to user_ids parameter. This must be either int or np.int32 array. Type received: {type(user_ids)}"
+            )
 
         if isinstance(item_ids, (list, tuple)):
             item_ids = np.array(item_ids, dtype=np.int32)

--- a/lightfm/lightfm.py
+++ b/lightfm/lightfm.py
@@ -781,8 +781,10 @@ class LightFM(object):
 
         self._check_initialized()
 
-        if not isinstance(user_ids, np.ndarray):
+        if not isinstance(user_ids, np.ndarray) and isinstance(user_ids, int):
             user_ids = np.repeat(np.int32(user_ids), len(item_ids))
+
+        assert isinstance(user_ids, np.ndarray)
 
         if isinstance(item_ids, (list, tuple)):
             item_ids = np.array(item_ids, dtype=np.int32)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -88,7 +88,7 @@ def test_predict():
         scores_int = model.predict(uid, np.arange(no_items))
         assert np.allclose(scores_arr, scores_int)
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(TypeError):
         model.predict("foo", np.arange(no_items))
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -89,7 +89,7 @@ def test_predict():
         assert np.allclose(scores_arr, scores_int)
 
     with pytest.raises(AssertionError):
-        model.predict('foo', np.arange(no_items))
+        model.predict("foo", np.arange(no_items))
 
 
 def test_input_dtypes():

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -88,6 +88,9 @@ def test_predict():
         scores_int = model.predict(uid, np.arange(no_items))
         assert np.allclose(scores_arr, scores_int)
 
+    with pytest.raises(AssertionError):
+        model.predict('foo', np.arange(no_items))
+
 
 def test_input_dtypes():
 


### PR DESCRIPTION
Closes #532 .

This is a small PR that just checks if the input to `LightFM.predict()` is in fact either `np.ndarray` or `int` type. It also includes a line in `test_predict()` to make sure this doesn't break later. The docs weren't changed because they already implied that the only acceptable input was `np.ndarray` or `int`.

Let me know if you'd rather not use an `AssertionError` there. I used it because a couple lines later there's another `assert` statement, and I figured you'd want some consistency.