### PR TITLE
Update to ensure user-item type handling parity in predict method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ doc/_build/*
 lightfm/_lightfm_fast_openmp.pyx
 lightfm/_lightfm_fast_no_openmp.pyx
 *.*-checkpoint
+.idea/*

--- a/.idea/lightfm.iml
+++ b/.idea/lightfm.iml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="PYTHON_MODULE" version="4">
-  <component name="NewModuleRootManager">
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="jdk" jdkName="Python 3.7 (magical-panini)" jdkType="Python SDK" />
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>

--- a/.idea/lightfm.iml
+++ b/.idea/lightfm.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="jdk" jdkName="Python 3.7 (magical-panini)" jdkType="Python SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/lightfm/lightfm.py
+++ b/lightfm/lightfm.py
@@ -784,17 +784,17 @@ class LightFM(object):
         if isinstance(user_ids, int):
             user_ids = np.repeat(np.int32(user_ids), len(item_ids))
 
-        if not isinstance(user_ids, np.ndarray):
-            raise TypeError(
-                f"Invalid type passed to user_ids parameter. "
-                f"This must be either int or np.int32 array. "
-                f"Type received: {type(user_ids)}"
-            )
+        if isinstance(user_ids, (list, tuple)):
+            user_ids = np.array(user_ids, dtype=np.int32)
 
         if isinstance(item_ids, (list, tuple)):
             item_ids = np.array(item_ids, dtype=np.int32)
 
-        assert len(user_ids) == len(item_ids)
+        if len(user_ids) != len(item_ids):
+            raise ValueError(
+                f"Expected length of user IDs ({len(user_ids)}) to equal item IDs "
+                f"({len(item_ids)})"
+            )
 
         if user_ids.dtype != np.int32:
             user_ids = user_ids.astype(np.int32)

--- a/lightfm/lightfm.py
+++ b/lightfm/lightfm.py
@@ -777,6 +777,26 @@ class LightFM(object):
         np.float32 array of shape [n_pairs,]
             Numpy array containing the recommendation scores for pairs defined
             by the inputs.
+
+        Notes
+        -----
+
+        As indicated above, this method returns an array of scores corresponding to the
+        score assigned by the model to _pairs of inputs_. Importantly, this means the
+        i-th element of the output array corresponds to the score for the i-th user-item
+        pair in the input arrays.
+
+        Concretely, you should expect the `lfm.predict([0, 1], [8, 9])` to return an
+        array of np.float32 that may look something like `[0.42  0.31]`, where `0.42` is
+        the score assigned to the user-item pair `(0, 8)` and `0.31` the score assigned
+        to pair `(1, 9)` respectively.
+
+        In other words, if you wish to generate the score for a few items (e.g.
+        `[7, 8, 9]`) for two users (e.g. `[0, 1]`), a proper way to call this method
+        would be to use `lfm.predict([0, 0, 0, 1, 1, 1], [7, 8, 9, 7, 8, 9])`, and
+        _not_ `lfm.predict([0, 1], [7, 8, 9])` as you may initially expect (this will
+        throw an exception!).
+
         """
 
         self._check_initialized()

--- a/lightfm/lightfm.py
+++ b/lightfm/lightfm.py
@@ -792,8 +792,8 @@ class LightFM(object):
 
         if len(user_ids) != len(item_ids):
             raise ValueError(
-                f"Expected length of user IDs ({len(user_ids)}) to equal item IDs "
-                f"({len(item_ids)})"
+                f"Expected the number of user IDs ({len(user_ids)}) to equal the number"
+                f" of item IDs ({len(item_ids)})"
             )
 
         if user_ids.dtype != np.int32:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -70,7 +70,7 @@ def test_coo_with_duplicate_entries():
     mat.col = np.concatenate((mat.col, mat.col[:1000]))
 
     for loss in ("warp", "bpr", "warp-kos"):
-        model = LightFM(loss="warp")
+        model = LightFM(loss=loss)
         model.fit(mat)
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -88,7 +88,7 @@ def test_predict():
         scores_int = model.predict(uid, np.arange(no_items))
         assert np.allclose(scores_arr, scores_int)
 
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         model.predict("foo", np.arange(no_items))
 
 

--- a/tests/test_movielens.py
+++ b/tests/test_movielens.py
@@ -704,7 +704,7 @@ def test_sklearn_cv():
             for _ in range(self.n_splits):
                 yield idx, idx
 
-    cv = CV(n_splits=3, random_state=42)
+    cv = CV(n_splits=3, random_state=42, shuffle=True)
     search = RandomizedSearchCV(
         estimator=model,
         param_distributions=distr,


### PR DESCRIPTION
Hey!

I've submitted this PR primarily to resolve a minor issue that (I feel) violates 'the principle of least surprise'.

The `predict` method accepts `user_ids` and `item_ids` parameters. For `item_ids`, a couple of coercion steps are used to massage the input into a `ndarray` of type `np.int32`. This includes casting `item_ids` of type `list` and `tuple` to `ndarray` as needed. In contrast, if `user_ids` are provided as a type other than `ndarray`, a `TypeError` is raised. In other words, if I call `lfm.predict(user_ids=[0, 1, 2, 3], item_ids=[7, 6, 5, 4])` would currently throw a `TypeError` for the type of the `user_ids` parameter, but not the `item_ids` parameter. This PR ensures parity between the two.

I've also switched out the assertion used to check `user_ids` and `item_ids` in favour of a conditional that raises a `ValueError` instead. I've updated tests accordingly. 

This PR depends on #587.