### PR TITLE
Add new unit test for type checking logic

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,7 @@ def array_int32(rng, size=10):
     params=[tuple, list, np.array]
 )
 def user_ids(array_int32, request):
-    """Initialise valid input user_ids for calls to the LightFM.predict method.
+    """Initialise input user_ids valid for calls to the LightFM.predict method.
 
     Notes
     -----
@@ -51,7 +51,7 @@ def user_ids(array_int32, request):
     params=[tuple, list, np.array]
 )
 def item_ids(array_int32, request):
-    """Initialise valid input item_ids for calls to the LightFM.predict method.
+    """Initialise input item_ids valid for calls to the LightFM.predict method.
 
     Notes
     -----

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,79 @@
+import pytest
+import numpy as np
+import scipy.sparse as sp
+
+from lightfm import LightFM
+
+# set our default random seed
+SEED = 42
+
+
+@pytest.fixture(scope="session")
+def rng():
+    """Initialise a shared random number generator for all tests."""
+
+    return np.random.RandomState(SEED)
+
+
+@pytest.fixture(scope="session")
+def array_int32(rng, size=10):
+    """Initialise an array of type np.int32 of size `size`."""
+
+    return rng.randint(0, 100, size=size, dtype=np.int32)
+
+
+@pytest.fixture(
+    scope="session",
+    ids=["tuple", "list", "ndarray"],
+    params=[tuple, list, np.array]
+)
+def user_ids(array_int32, request):
+    """Initialise valid input user_ids for calls to the LightFM.predict method.
+
+    Notes
+    -----
+    On parameterized pytest fixtures: This fixture will iterate over all passed
+    `params`. This avoids having to apply a `pytest.mark.parameterize` decorator to
+    every test that needs the same `user_ids`.
+
+    You can find out more about parameterized fixtures in the pytest docs:
+    https://docs.pytest.org/en/stable/parametrize.html
+
+    """
+
+    _type = request.param
+    yield _type(array_int32)
+
+
+@pytest.fixture(
+    scope="session",
+    ids=["tuple", "list", "ndarray"],
+    params=[tuple, list, np.array]
+)
+def item_ids(array_int32, request):
+    """Initialise valid input item_ids for calls to the LightFM.predict method.
+
+    Notes
+    -----
+    See `user_ids` fixture for a note on parameterized fixtures.
+
+    """
+    _type = request.param
+    yield _type(array_int32)
+
+
+@pytest.fixture(scope="session")
+def train_matrix(rng, n_users=1000, n_items=1000):
+    """Create a random sparse CSR matrix of shape (n_users, n_items) for training."""
+
+    return sp.rand(n_users, n_items, format="csr", random_state=rng)
+
+
+@pytest.fixture(scope="session")
+def lfm(train_matrix):
+    """Create a _trained_ LightFM model instance."""
+
+    model = LightFM()
+    model.fit(train_matrix)
+
+    return model

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -382,7 +382,7 @@ def test_warp_few_items():
     model.fit(train)
 
 
-def test_predict_input_arrays_with_valid_types(lfm, user_ids, item_ids):
+def test_predict_user_item_inputs_with_valid_types(lfm, user_ids, item_ids):
     """Test that calls to the predict method with inputs of valid types succeed."""
 
     # GIVEN user_ids of a valid type

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -382,7 +382,7 @@ def test_warp_few_items():
     model.fit(train)
 
 
-def test_predict_input_with_valid_types(lfm, user_ids, item_ids):
+def test_predict_input_arrays_with_valid_types(lfm, user_ids, item_ids):
     """Test that calls to the predict method with inputs of valid types succeed."""
 
     # GIVEN user_ids of a valid type

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -380,3 +380,16 @@ def test_warp_few_items():
     model = LightFM(loss="warp", max_sampled=10)
 
     model.fit(train)
+
+
+def test_predict_input_with_valid_types(lfm, user_ids, item_ids):
+    """Test that calls to the predict method with inputs of valid types succeed."""
+
+    # GIVEN user_ids of a valid type (tuple, list, ndarray)
+    # AND item_ids of a valid type (tuple, list, ndarray)
+    # WHEN trained model provided
+    # THEN calls to LightFM.predict succeed
+
+    h = lfm.predict(user_ids=user_ids, item_ids=item_ids)
+    assert h.dtype == np.float32
+    assert len(h) == len(user_ids)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -385,8 +385,8 @@ def test_warp_few_items():
 def test_predict_input_with_valid_types(lfm, user_ids, item_ids):
     """Test that calls to the predict method with inputs of valid types succeed."""
 
-    # GIVEN user_ids of a valid type (tuple, list, ndarray)
-    # AND item_ids of a valid type (tuple, list, ndarray)
+    # GIVEN user_ids of a valid type
+    # AND item_ids of a valid type
     # WHEN trained model provided
     # THEN calls to LightFM.predict succeed
 


### PR DESCRIPTION
Hey again!

In response @maciejkula's [request](https://github.com/lyst/lightfm/pull/588/files/e7e4e825da2861ee455d147faef4dcc6062d812b#r571695680) on #588 I've added a test to check all combinations of valid input types for `user_ids` and `item_ids` (i.e. `tuple`, `list`, `ndarray`) pass successfully.

To do this, I've added a [`conftest.py` file](https://docs.pytest.org/en/2.1.0/plugins.html) that includes some handy fixtures for the new `test_predict_input_with_valid_types` test. 

As an aside, I think some of these fixtures might be useful in other tests (not addressed in this PR) too. I'd be happy to look into how existing tests could be streamlined if that would be useful?
