### PR TITLE
Skip march=native for apple

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@ import os
 import pathlib
 import subprocess
 import sys
-import platform
 import textwrap
 
 from setuptools import Command, Extension, setup
@@ -18,7 +17,7 @@ def define_extensions(use_openmp):
     if not os.environ.get("LIGHTFM_NO_CFLAGS"):
         compile_args += ["-ffast-math"]
 
-        if platform.system() == "Darwin":
+        if sys.platform.startswith("darwin"):
             compile_args += []
         else:
             compile_args += ["-march=native"]

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ import os
 import pathlib
 import subprocess
 import sys
+import platform
 import textwrap
 
 from setuptools import Command, Extension, setup
@@ -15,16 +16,12 @@ from lightfm import __version__ as version  # NOQA
 def define_extensions(use_openmp):
     compile_args = []
     if not os.environ.get("LIGHTFM_NO_CFLAGS"):
-        compile_args.append("-ffast-math")
+        compile_args += ["-ffast-math"]
 
-        # There are problems with illegal ASM instructions
-        # when using the Anaconda distribution (at least on OSX).
-        # This could be because Anaconda uses its own assembler?
-        # To work around this we do not add -march=native if we
-        # know we're dealing with Anaconda or if CFLAGS is set
-        # with a requestsed arch
-        if "anaconda" not in sys.version.lower():
-            compile_args.append("-march=native")
+        if platform.system() == "Darwin":
+            compile_args += []
+        else:
+            compile_args += ["-march=native"]
 
     if not use_openmp:
         print("Compiling without OpenMP support.")


### PR DESCRIPTION
In response to https://github.com/lyst/lightfm/issues/622.

I skip the `march=native` for MacOs to avoid problems with apple silicone. This might result in a performance loss but we go the same route when building for conda-forge and in my personal experience, there wasn't a noticeable performance hit. I decided against specifying `-mcpu=apple-m1` because I am not sure how stable/robust the flag is and whether requirements towards the compiler toolchain would be too restrictive.

I took some inspiration from this thread https://github.com/irmen/pyminiaudio/issues/30

Other:
- I removed the condition on "anaconda". Afaik, this was a problem with macOS and should be covered with the above.