### PR TITLE
Upgrade from depreacted version 1 compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   lightfm:
     build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,11 @@
-lightfm:
-  build: .
-  # Uncomment this to mount your local version
-  # of the LightFM code.
-  # volumes:
-  #   - .:/home/lightfm/
-  ports:
-  - "8888:8888"
+version: '3'
+
+services:
+  lightfm:
+    build: .
+    # Uncomment this to mount your local version
+    # of the LightFM code.
+    # volumes:
+    #   - .:/home/lightfm/
+    ports:
+    - "8888:8888"


### PR DESCRIPTION
Small upgrade from the deprecated version 1 composes file. The only change is that all services must be declared under the `services` key (https://docs.docker.com/compose/compose-file/compose-versioning/#version-2)