### PR TITLE
Upgrade deprecated circleci images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,9 +72,6 @@ workflows:
     jobs:
       - lint
       - pytest:
-          image: cimg/python:3.10
-          python_version: py310
-      - pytest:
           image: cimg/python:3.9
           python_version: py39
       - pytest:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,5 @@
+version: 2.1
+
 jobs:
   pytest:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,17 +46,17 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - deps-lint-{{ .Branch }}-{{ checksum "lint-requirements.txt"}}
-            - deps-lint-{{ .Branch }}-
-            - deps-lint-
+            - v2-deps-lint-{{ .Branch }}-{{ checksum "lint-requirements.txt"}}
+            - v2-deps-lint-{{ .Branch }}-
+            - v2-deps-lint-
       - run:
           name: Install lint requirements
           command: |
             python3 -m venv venv
             . venv/bin/activate
-            pip install -r "lint-requirements.txt"
+            pip install -r lint-requirements.txt
       - save_cache:
-          key: deps-lint-{{ .Branch }}-{{ checksum "lint-requirements.txt" }}
+          key: v2-deps-lint-{{ .Branch }}-{{ checksum "lint-requirements.txt" }}
           paths:
             - "venv"
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
           path: test_results
   lint:
     docker:
-      - image: circleci/python:3.8.3-buster
+      - image: cimg/python:3.8
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,9 @@
-version: 2.1
-
 jobs:
   pytest:
     parameters:
       image:
         description: "Docker image to run tests in"
-        default: "circleci/python:3.8.3-buster-browsers"
+        default: cimg/python:3.8
         type: string
       python_version:
         description: "Python version used to separate cache"
@@ -72,11 +70,14 @@ workflows:
     jobs:
       - lint
       - pytest:
-          image: circleci/python:3.6.10-stretch-browsers
-          python_version: py36
+          image: cimg/python:3.10
+          python_version: py310
       - pytest:
-          image: circleci/python:3.7.7-buster-browsers
-          python_version: py37
+          image: cimg/python:3.9
+          python_version: py39
       - pytest:
-          image: circleci/python:3.8.3-buster-browsers
+          image: cimg/python:3.8
           python_version: py38
+      - pytest:
+          image: cimg/python:3.7
+          python_version: py37

--- a/README.md
+++ b/README.md
@@ -81,6 +81,6 @@ Pull requests are welcome. To install for development:
 2. Setup a virtual environment: `cd lightfm && python3 -m venv venv && source ./venv/bin/activate`
 3. Install it for development using pip: `pip install -e . && pip install -r test-requirements.txt`
 4. You can run tests by running `./venv/bin/py.test tests`.
-5. LightFM uses [black](https://github.com/ambv/black) (version `18.6b4`) to enforce code formatting.
+5. LightFM uses [black](https://github.com/ambv/black) to enforce code formatting, see `lint-requirements.txt`.
 
 When making changes to the `.pyx` extension files, you'll need to run `python setup.py cythonize` in order to produce the extension `.c` files before running `pip install -e .`.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -20,42 +20,42 @@ import lightfm
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.insert(0, os.path.abspath('..'))
+sys.path.insert(0, os.path.abspath(".."))
 
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-#needs_sphinx = '1.0'
+# needs_sphinx = '1.0'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.doctest',
-    'sphinx.ext.githubpages',
-    'sphinx.ext.napoleon',
-    'sphinx.ext.viewcode',
+    "sphinx.ext.autodoc",
+    "sphinx.ext.doctest",
+    "sphinx.ext.githubpages",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.viewcode",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 # source_suffix = ['.rst', '.md']
-source_suffix = '.rst'
+source_suffix = ".rst"
 
 # The encoding of source files.
-#source_encoding = 'utf-8-sig'
+# source_encoding = 'utf-8-sig'
 
 # The master toctree document.
-master_doc = 'index'
+master_doc = "index"
 
 # General information about the project.
-project = u'LightFM'
-copyright = u'2016, Lyst (Maciej Kula)'
-author = u'Lyst (Maciej Kula)'
+project = "LightFM"
+copyright = "2016, Lyst (Maciej Kula)"
+author = "Lyst (Maciej Kula)"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -75,38 +75,38 @@ language = None
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
-#today = ''
+# today = ''
 # Else, today_fmt is used as the format for a strftime call.
-#today_fmt = '%B %d, %Y'
+# today_fmt = '%B %d, %Y'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
-#default_role = None
+# default_role = None
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
-#add_function_parentheses = True
+# add_function_parentheses = True
 
 # If true, the current module name will be prepended to all description
 # unit titles (such as .. function::).
-#add_module_names = True
+# add_module_names = True
 
 # If true, sectionauthor and moduleauthor directives will be shown in the
 # output. They are ignored by default.
-#show_authors = False
+# show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = "sphinx"
 
 # A list of ignored prefixes for module index sorting.
-#modindex_common_prefix = []
+# modindex_common_prefix = []
 
 # If true, keep warnings as "system message" paragraphs in the built documents.
-#keep_warnings = False
+# keep_warnings = False
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
@@ -116,31 +116,31 @@ todo_include_todos = False
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'sphinx_rtd_theme'
+html_theme = "sphinx_rtd_theme"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-#html_theme_options = {}
+# html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
-#html_theme_path = []
+# html_theme_path = []
 
 # The name for this set of Sphinx documents.
 # "<project> v<release> documentation" by default.
-#html_title = u'LightFM v1.8'
+# html_title = u'LightFM v1.8'
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
-#html_short_title = None
+# html_short_title = None
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-#html_logo = None
+# html_logo = None
 
 # The name of an image file (relative to this directory) to use as a favicon of
 # the docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
-#html_favicon = None
+# html_favicon = None
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
@@ -150,124 +150,123 @@ html_static_path = []
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.
-#html_extra_path = []
+# html_extra_path = []
 
 # If not None, a 'Last updated on:' timestamp is inserted at every page
 # bottom, using the given strftime format.
 # The empty string is equivalent to '%b %d, %Y'.
-#html_last_updated_fmt = None
+# html_last_updated_fmt = None
 
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.
-#html_use_smartypants = True
+# html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
-#html_sidebars = {}
+# html_sidebars = {}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.
-#html_additional_pages = {}
+# html_additional_pages = {}
 
 # If false, no module index is generated.
-#html_domain_indices = True
+# html_domain_indices = True
 
 # If false, no index is generated.
-#html_use_index = True
+# html_use_index = True
 
 # If true, the index is split into individual pages for each letter.
-#html_split_index = False
+# html_split_index = False
 
 # If true, links to the reST sources are added to the pages.
-#html_show_sourcelink = True
+# html_show_sourcelink = True
 
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
-#html_show_sphinx = True
+# html_show_sphinx = True
 
 # If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
-#html_show_copyright = True
+# html_show_copyright = True
 
 # If true, an OpenSearch description file will be output, and all pages will
 # contain a <link> tag referring to it.  The value of this option must be the
 # base URL from which the finished HTML is served.
-#html_use_opensearch = ''
+# html_use_opensearch = ''
 
 # This is the file name suffix for HTML files (e.g. ".xhtml").
-#html_file_suffix = None
+# html_file_suffix = None
 
 # Language to be used for generating the HTML full-text search index.
 # Sphinx supports the following languages:
 #   'da', 'de', 'en', 'es', 'fi', 'fr', 'hu', 'it', 'ja'
 #   'nl', 'no', 'pt', 'ro', 'ru', 'sv', 'tr', 'zh'
-#html_search_language = 'en'
+# html_search_language = 'en'
 
 # A dictionary with options for the search language support, empty by default.
 # 'ja' uses this config value.
 # 'zh' user can custom change `jieba` dictionary path.
-#html_search_options = {'type': 'default'}
+# html_search_options = {'type': 'default'}
 
 # The name of a javascript file (relative to the configuration directory) that
 # implements a search results scorer. If empty, the default will be used.
-#html_search_scorer = 'scorer.js'
+# html_search_scorer = 'scorer.js'
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'LightFMdoc'
+htmlhelp_basename = "LightFMdoc"
 
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {
-# The paper size ('letterpaper' or 'a4paper').
-#'papersize': 'letterpaper',
-
-# The font size ('10pt', '11pt' or '12pt').
-#'pointsize': '10pt',
-
-# Additional stuff for the LaTeX preamble.
-#'preamble': '',
-
-# Latex figure (float) alignment
-#'figure_align': 'htbp',
+    # The paper size ('letterpaper' or 'a4paper').
+    #'papersize': 'letterpaper',
+    # The font size ('10pt', '11pt' or '12pt').
+    #'pointsize': '10pt',
+    # Additional stuff for the LaTeX preamble.
+    #'preamble': '',
+    # Latex figure (float) alignment
+    #'figure_align': 'htbp',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'LightFM.tex', u'LightFM Documentation',
-     u'Lyst (Maciej Kula)', 'manual'),
+    (
+        master_doc,
+        "LightFM.tex",
+        "LightFM Documentation",
+        "Lyst (Maciej Kula)",
+        "manual",
+    ),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.
-#latex_logo = None
+# latex_logo = None
 
 # For "manual" documents, if this is true, then toplevel headings are parts,
 # not chapters.
-#latex_use_parts = False
+# latex_use_parts = False
 
 # If true, show page references after internal links.
-#latex_show_pagerefs = False
+# latex_show_pagerefs = False
 
 # If true, show URL addresses after external links.
-#latex_show_urls = False
+# latex_show_urls = False
 
 # Documents to append as an appendix to all manuals.
-#latex_appendices = []
+# latex_appendices = []
 
 # If false, no module index is generated.
-#latex_domain_indices = True
+# latex_domain_indices = True
 
 
 # -- Options for manual page output ---------------------------------------
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [
-    (master_doc, 'lightfm', u'LightFM Documentation',
-     [author], 1)
-]
+man_pages = [(master_doc, "lightfm", "LightFM Documentation", [author], 1)]
 
 # If true, show URL addresses after external links.
-#man_show_urls = False
+# man_show_urls = False
 
 
 # -- Options for Texinfo output -------------------------------------------
@@ -276,22 +275,28 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'LightFM', u'LightFM Documentation',
-     author, 'LightFM', 'One line description of project.',
-     'Miscellaneous'),
+    (
+        master_doc,
+        "LightFM",
+        "LightFM Documentation",
+        author,
+        "LightFM",
+        "One line description of project.",
+        "Miscellaneous",
+    ),
 ]
 
 # Documents to append as an appendix to all manuals.
-#texinfo_appendices = []
+# texinfo_appendices = []
 
 # If false, no module index is generated.
-#texinfo_domain_indices = True
+# texinfo_domain_indices = True
 
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
-#texinfo_show_urls = 'footnote'
+# texinfo_show_urls = 'footnote'
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
-#texinfo_no_detailmenu = False
+# texinfo_no_detailmenu = False
 
 # Compact attribute lists
 napoleon_use_ivar = True

--- a/examples/dataset/download.py
+++ b/examples/dataset/download.py
@@ -11,13 +11,15 @@ def _download(url: str, dest_path: str):
     req.raise_for_status()
 
     with open(dest_path, "wb") as fd:
-        for chunk in req.iter_content(chunk_size=2 ** 20):
+        for chunk in req.iter_content(chunk_size=2**20):
             fd.write(chunk)
 
 
 def get_data():
 
-    ratings_url = ("http://www2.informatik.uni-freiburg.de/" "~cziegler/BX/BX-CSV-Dump.zip")
+    ratings_url = (
+        "http://www2.informatik.uni-freiburg.de/" "~cziegler/BX/BX-CSV-Dump.zip"
+    )
 
     if not os.path.exists("data"):
         os.makedirs("data")
@@ -27,11 +29,15 @@ def get_data():
     with zipfile.ZipFile("data/data.zip") as archive:
         return (
             csv.DictReader(
-                (x.decode("utf-8", "ignore") for x in archive.open("BX-Book-Ratings.csv")),
+                (
+                    x.decode("utf-8", "ignore")
+                    for x in archive.open("BX-Book-Ratings.csv")
+                ),
                 delimiter=";",
             ),
             csv.DictReader(
-                (x.decode("utf-8", "ignore") for x in archive.open("BX-Books.csv")), delimiter=";"
+                (x.decode("utf-8", "ignore") for x in archive.open("BX-Books.csv")),
+                delimiter=";",
             ),
         )
 

--- a/examples/movielens/data.py
+++ b/examples/movielens/data.py
@@ -14,8 +14,7 @@ def _get_movielens_path():
     Get path to the movielens dataset file.
     """
 
-    return os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                        'movielens.zip')
+    return os.path.join(os.path.dirname(os.path.abspath(__file__)), "movielens.zip")
 
 
 def _download_movielens(dest_path):
@@ -23,10 +22,10 @@ def _download_movielens(dest_path):
     Download the dataset.
     """
 
-    url = 'http://files.grouplens.org/datasets/movielens/ml-100k.zip'
+    url = "http://files.grouplens.org/datasets/movielens/ml-100k.zip"
     req = requests.get(url, stream=True)
 
-    with open(dest_path, 'wb') as fd:
+    with open(dest_path, "wb") as fd:
         for chunk in req.iter_content():
             fd.write(chunk)
 
@@ -42,8 +41,10 @@ def _get_raw_movielens_data():
         _download_movielens(path)
 
     with zipfile.ZipFile(path) as datafile:
-        return (datafile.read('ml-100k/ua.base').decode().split('\n'),
-                datafile.read('ml-100k/ua.test').decode().split('\n'))
+        return (
+            datafile.read("ml-100k/ua.base").decode().split("\n"),
+            datafile.read("ml-100k/ua.test").decode().split("\n"),
+        )
 
 
 def _parse(data):
@@ -56,7 +57,7 @@ def _parse(data):
         if not line:
             continue
 
-        uid, iid, rating, timestamp = [int(x) for x in line.split('\t')]
+        uid, iid, rating, timestamp = [int(x) for x in line.split("\t")]
 
         yield uid, iid, rating, timestamp
 
@@ -90,7 +91,7 @@ def _get_movie_raw_metadata():
         _download_movielens(path)
 
     with zipfile.ZipFile(path) as datafile:
-        return datafile.read('ml-100k/u.item').decode(errors='ignore').split('\n')
+        return datafile.read("ml-100k/u.item").decode(errors="ignore").split("\n")
 
 
 def get_movielens_item_metadata(use_item_ids):
@@ -108,12 +109,12 @@ def get_movielens_item_metadata(use_item_ids):
         if not line:
             continue
 
-        splt = line.split('|')
+        splt = line.split("|")
         item_id = int(splt[0])
 
-        genres = [idx for idx, val in
-                  zip(range(len(splt[5:])), splt[5:])
-                  if int(val) > 0]
+        genres = [
+            idx for idx, val in zip(range(len(splt[5:])), splt[5:]) if int(val) > 0
+        ]
 
         if use_item_ids:
             # Add item-specific features too
@@ -124,9 +125,7 @@ def get_movielens_item_metadata(use_item_ids):
 
         features[item_id] = genres
 
-    mat = sp.lil_matrix((len(features) + 1,
-                         len(genre_set)),
-                        dtype=np.int32)
+    mat = sp.lil_matrix((len(features) + 1, len(genre_set)), dtype=np.int32)
 
     for item_id, genre_ids in features.items():
         for genre_id in genre_ids:
@@ -145,13 +144,16 @@ def get_movielens_data():
     uids = set()
     iids = set()
 
-    for uid, iid, rating, timestamp in itertools.chain(_parse(train_data),
-                                                       _parse(test_data)):
+    for uid, iid, rating, timestamp in itertools.chain(
+        _parse(train_data), _parse(test_data)
+    ):
         uids.add(uid)
         iids.add(iid)
 
     rows = max(uids) + 1
     cols = max(iids) + 1
 
-    return (_build_interaction_matrix(rows, cols, _parse(train_data)),
-            _build_interaction_matrix(rows, cols, _parse(test_data)))
+    return (
+        _build_interaction_matrix(rows, cols, _parse(train_data)),
+        _build_interaction_matrix(rows, cols, _parse(test_data)),
+    )

--- a/lightfm/datasets/_common.py
+++ b/lightfm/datasets/_common.py
@@ -20,7 +20,7 @@ def download(url, dest_path):
     req.raise_for_status()
 
     with open(dest_path, "wb") as fd:
-        for chunk in req.iter_content(chunk_size=2 ** 20):
+        for chunk in req.iter_content(chunk_size=2**20):
             fd.write(chunk)
 
 

--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,3 +1,3 @@
 pre-commit
-black=~21.1
-flake8=~4.0
+black~=21.1
+flake8~=4.0

--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,3 +1,3 @@
 pre-commit
-black~=21.1
+black~=22.1
 flake8~=4.0

--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,2 +1,3 @@
-black
-flake8
+pre-commit
+black=~21.1
+flake8=~4.0

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -73,7 +73,7 @@ def test_build_features():
             for user_id in range(users)
         ]
     )
-    assert user_features.getnnz() == users ** 2
+    assert user_features.getnnz() == users**2
 
     item_features = dataset.build_item_features(
         [
@@ -81,7 +81,7 @@ def test_build_features():
             for item_id in range(items)
         ]
     )
-    assert item_features.getnnz() == items ** 2
+    assert item_features.getnnz() == items**2
 
     # Build from dicts
     user_features = dataset.build_user_features(


### PR DESCRIPTION
This upgrades to the new circleci convenience images. The formerly used images are deprecated. See: https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034
 
A few other changes stacked up while fixing the CI/CD Pipeline: 
- Removed python 3.6 from test matrix (reached end of life)
- Added python 3.9 to test matrix
- Fixed the black version to have deterministic re-formatting
- Re-format repo with new black version (all in one commit: [80195429dbe374cd57dac11a762a92c63e1224de](https://github.com/lyst/lightfm/pull/629/commits/22e1c3b91006e9c917b9d6f627dc33648e651304))
- I initially tried to add python 3.10 but there were a few problems with the setup.py