### PR TITLE
Update dependencies for creating Docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ lightfm/_lightfm_fast_no_openmp.pyx
 # Editor specific
 .vscode/
 .idea/
+.devcontainer/

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -16,6 +16,8 @@ import sys
 import os
 
 import lightfm
+import sphinx_rtd_theme
+
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -36,6 +38,7 @@ extensions = [
     "sphinx.ext.githubpages",
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
+    'sphinx_rtd_theme',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,0 +1,2 @@
+sphinx>=4.0
+sphinx_rtd_theme>=1.0


### PR DESCRIPTION
Hi @maciejkula,

I changed a few lines in doc/conf.py that were necessary to build the docs with a newer sphinx version. I also added a `docs-requirements.txt`. 

In my opinion, having three requirements files is quite ugly and development usually requires all three of them. However, without using sth. like pryproject.toml I don't have a better idea for organizing this (also considering minimal installation for CI/CD). 

Also: 
- Added .devcontainer to the gitignore. This allows me and others to use the VSCode devcontainer feature to develop for linux/amd64 on an apple m1. 