### PR TITLE
docs: fix simple typo, secion -> section

### DIFF
--- a/doc/home.rst
+++ b/doc/home.rst
@@ -21,7 +21,7 @@ PyPI
 
 Install from pypi using pip: ``pip install lightfm``. Everything should work out-of-the box on Linux, OSX using Homebrew Python, and Windows using Miniconda.
 
-Note for OSX and Windows users: LightFM will by default not use OpenMP on OSX and Windows, and so all model fitting will be single-threaded. This is due to the fact that Clang (and Miniconda) does not support OpenMP, and installing an OpenMP-enabled version of gcc is complicated and labour-intensive. If you'd like to use the multi-threading capabilities of LightFM on these platforms, you should try using it via Docker as described in the next secion.
+Note for OSX and Windows users: LightFM will by default not use OpenMP on OSX and Windows, and so all model fitting will be single-threaded. This is due to the fact that Clang (and Miniconda) does not support OpenMP, and installing an OpenMP-enabled version of gcc is complicated and labour-intensive. If you'd like to use the multi-threading capabilities of LightFM on these platforms, you should try using it via Docker as described in the next section.
 
 Building with the default Python distribution included in OSX is also not supported; please try the version from Homebrew or Anaconda.
 


### PR DESCRIPTION
There is a small typo in doc/home.rst.

Should read `section` rather than `secion`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md